### PR TITLE
feat(license): Relicense to Parity-6.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "3.0.0"
 authors = ["Kat Marchán <kzm@zkat.tech>"]
 edition = "2018"
 description = "Various utilities for handling Subresource Integrity."
-license = "MIT OR Apache-2.0"
+license = "Parity-6.0.0"
 repository = "https://github.com/zkat/ssri-rs"
 homepage = "https://github.com/zkat/ssri-rs"
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,59 @@
+The Parity Public License 6.0.0
+
+Contributor: Kat Marchán
+
+Source Code: https://github.com/zkat/ssri-rs
+
+This license lets you use and share this software for free, as
+long as you contribute software you make with it. Specifically:
+
+If you follow the rules below, you may do everything with this
+software that would otherwise infringe either the contributor's
+copyright in it, any patent claim the contributor can license,
+or both.
+
+1. Contribute changes and additions you make to this software.
+
+2. If you combine this software with other software, contribute
+   that other software.
+
+3. Contribute software you develop, deploy, monitor, or run with
+   this software.
+
+4. Ensure everyone who gets a copy of this software from you, in
+   source code or any other form, gets the text of this license
+   and the contributor and source code lines above.
+
+5. Do not make any legal claim against anyone accusing this
+   software, with or without changes, alone or with other
+   software, of infringing any patent claim.
+
+To contribute software, publish all its source code, in the
+preferred form for making changes, through a freely accessible
+distribution system widely used for similar source code, and
+license contributions not already licensed to the public on terms
+as permissive as this license accordingly.
+
+You are excused for unknowingly breaking 1, 2, or 3 if you
+contribute as required, or stop doing anything requiring this
+license, within 30 days of learning you broke the rule.
+
+**As far as the law allows, this software comes as is, without
+any warranty, and the contributor will not be liable to anyone
+for any damages related to this software or this license, for any
+kind of legal claim.**
+
+
+---
+
+Licensor Signature (Ed25519):
+
+41a412caba1f220afaf9e8c27175b7b2dabd6dc3a101d23c3bccbb2c1e4e0cc8
+18a78619764243ada443a9d3609f31d542fbf62dc5c23e25a7bcdaf7b56de10a
+
+---
+
+Agent Signature (Ed25519):
+
+e8956dc07ac75da3cf544129c64dba7a8d6ea6abd1654660350f8857d79631cc
+6e63a2eef1f5325518e648af12dd932efb30fc7c2c826ce1da2c8d2a0257560a

--- a/PATRONAGE.md
+++ b/PATRONAGE.md
@@ -1,0 +1,61 @@
+# Patron License 1.0.0-draft.3
+
+Payment Platforms:
+- https://github.com/users/zkat/sponsors
+
+Participating Contributors:
+- Kat Marchán
+
+## Purpose
+
+This license gives everyone supporting contributors to this software as qualifying patrons permission to ignore any noncommercial or copyleft rules of its free public license, while continuing to protect contributors from liability.
+
+## Acceptance
+
+In order to agree to these terms and receive a license, you must qualify under [Patrons](#patrons).  The rules of these terms are both obligations under your agreement and conditions to your license.  That agreement and your license continue only while you qualify as a patron.  You must not do anything with this software that triggers a rule that you cannot or will not follow.
+
+## Patrons
+
+To accept these terms, you must be enrolled to make regular payments through any of the payment platforms pages listed above, in amounts qualifying you for a tier of rewards that includes "patron licenses" or otherwise identifies licenses under these terms.
+
+## Scope
+
+Except under [Seat](#seat) and [Applications](#applications), you may not sublicense or transfer any agreement or license under these terms to anyone else.
+
+## Seat
+
+If a legal entity, rather than an individual, accepts these terms, the entity may sublicense one individual employee or independent contractor at any given time.  If the employee or contractor beaks any rule of these terms, the entity will stand directly responsible.
+
+## Applications
+
+If you combine this software with other software in a larger application, you may sublicense this software as part of your larger application, and allow further sublicensing in turn, under these rules:
+
+1.  Your larger application must have significant additional content or functionality beyond that of this software, and end users must license your larger application primarily for that added content or functionality.
+
+2.  You may not sublicense anyone to break any rule of the public license for this software for any changes of their own or any software besides your larger application.
+
+3.  You may build, and sublicense for, as many larger applications as you like.
+
+## Copyright
+
+Each contributor licenses you to do everything with this software that would otherwise infringe that contributor's copyright in it.
+
+## Notices
+
+You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the texts of both this license and the free public license for this software.
+
+## Excuse
+
+If anyone notifies you in writing that you have not complied with [Notices](#notices), you can keep your agreement and your license by taking all practical steps to comply within 30 days after the notice.  If you do not do so, your agreement under these terms ends immediately, and your license ends with it.
+
+## Patent
+
+Each contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.
+
+## Reliability
+
+No contributor can revoke this license, but your license may end if you break any rules of these terms.
+
+## No Liability
+
+***As far as the law allows, this software comes as is, without any warranty or condition, and no contributor will be liable to anyone for any damages related to this software or this license, under any kind of legal claim.***

--- a/licensezero.json
+++ b/licensezero.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.0.0",
+  "licensezero": [
+    {
+      "agentSignature": "de1c7e969c9e3e034bc376ce9dbaabdbf5a7c6f9a8a1e0c93a81742a7a8846153308b853b991bc430fd1fa5ca34a56c9579b1b27970df1cabf2317710411180b",
+      "license": {
+        "homepage": "https://github.com/zkat/ssri-rs",
+        "jurisdiction": "US-CA",
+        "name": "Kat Marchán",
+        "projectID": "76b8e949-a561-44af-b955-a35e6ffe467e",
+        "publicKey": "5f60082194dc6b4a3971fa7397be663c81313bcaa489af96cfdef1c413b1b01a",
+        "terms": "parity",
+        "version": "6.0.0"
+      },
+      "licensorSignature": "8fe5f98642f320bc7177be5428e2cc7a2ad379066714d385d7e3244e34d140f28bae13398089b223dc9446f58b26dab73a4e28893da53d28c4756c77ef78e80e"
+    }
+  ]
+}


### PR DESCRIPTION
See also: https://paritylicense.com/ and https://blog.licensezero.com/2019/05/24/patron-license.html

BREAKING CHANGE: This changes the license to Parity-6.0.0, a strong copyleft license. Please make sure to read it and understand how the relevant changes might affect you going forward.