### PR TITLE
docs: add note that parsing from &str to Hash does not validate digests

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -36,6 +36,9 @@ impl fmt::Display for Hash {
 impl std::str::FromStr for Hash {
     type Err = Error;
 
+    /// Tries to parse a [&str] into a [struct@Hash].
+    /// Note the length of the digest is not validated to encode the number of
+    /// bytes expected by the chosen hash algorithm.
     fn from_str(s: &str) -> Result<Hash, Self::Err> {
         let mut parsed = s.trim().split(|c| c == '-');
         let algorithm = parsed


### PR DESCRIPTION
See https://github.com/zkat/ssri-rs/issues/5 for details.