### PR TITLE
fix(deps): upgrade dependencies to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ sha2 = "0.10"
 base64 = "0.10.1"
 digest = "0.10"
 sha-1 = "0.10"
-hex = "0.3.2"
+hex = "0.4"
 serde = { version = "1.0.152", optional = true }
 thiserror = "1.0.38"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ homepage = "https://github.com/zkat/ssri-rs"
 readme = "README.md"
 
 [dependencies]
-sha2 = "0.10"
-base64 = "0.21"
-digest = "0.10"
-sha-1 = "0.10"
-hex = "0.4"
+sha2 = "0.10.6"
+base64 = "0.21.0"
+digest = "0.10.6"
+sha-1 = "0.10.1"
+hex = "0.4.3"
 serde = { version = "1.0.152", optional = true }
 thiserror = "1.0.38"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ homepage = "https://github.com/zkat/ssri-rs"
 readme = "README.md"
 
 [dependencies]
-sha2 = "0.8.0"
+sha2 = "0.10"
 base64 = "0.10.1"
-digest = "0.8.0"
-sha-1 = "0.8.1"
+digest = "0.10"
+sha-1 = "0.10"
 hex = "0.3.2"
 serde = { version = "1.0.92", optional = true }
 thiserror = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 sha2 = "0.10"
-base64 = "0.10.1"
+base64 = "0.21"
 digest = "0.10"
 sha-1 = "0.10"
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ digest = "0.10"
 sha-1 = "0.10"
 hex = "0.3.2"
 serde = { version = "1.0.92", optional = true }
-thiserror = "1.0.3"
+thiserror = "1.0.38"
 
 [features]
 default = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ thiserror = "1.0.38"
 default = ["serde"]
 
 [dev-dependencies]
-serde_json = "1.0.57"
-serde_derive = "1.0.115"
+serde_json = "1.0.93"
+serde_derive = "1.0.152"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ base64 = "0.10.1"
 digest = "0.10"
 sha-1 = "0.10"
 hex = "0.3.2"
-serde = { version = "1.0.92", optional = true }
+serde = { version = "1.0.152", optional = true }
 thiserror = "1.0.38"
 
 [features]

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -20,7 +20,7 @@ pub enum Algorithm {
 
 impl fmt::Display for Algorithm {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", format!("{:?}", self).to_lowercase())
+        write!(f, "{}", format!("{self:?}").to_lowercase())
     }
 }
 
@@ -44,10 +44,10 @@ mod tests {
 
     #[test]
     fn algorithm_formatting() {
-        assert_eq!(format!("{}", Sha1), "sha1");
-        assert_eq!(format!("{}", Sha256), "sha256");
-        assert_eq!(format!("{}", Sha384), "sha384");
-        assert_eq!(format!("{}", Sha512), "sha512");
+        assert_eq!(format!("{Sha1}"), "sha1");
+        assert_eq!(format!("{Sha256}"), "sha256");
+        assert_eq!(format!("{Sha384}"), "sha384");
+        assert_eq!(format!("{Sha512}"), "sha512");
     }
 
     #[test]

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -70,7 +70,7 @@ mod tests {
             .parse::<Integrity>()
             .unwrap()
             .concat(Integrity::from(b"hello world"));
-        eprintln!("\n{}", sri);
+        eprintln!("\n{sri}");
         let result = IntegrityChecker::new(sri).chain(b"hello world").result();
         assert_eq!(result.unwrap(), Algorithm::Sha256)
     }

--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -189,7 +189,11 @@ impl Integrity {
         let hash = self.hashes.get(0).unwrap();
         (
             hash.algorithm,
-            hex::encode(base64::prelude::BASE64_STANDARD.encode(&hash.digest)),
+            hex::encode(
+                base64::prelude::BASE64_STANDARD
+                    .decode(&hash.digest)
+                    .unwrap(),
+            ),
         )
     }
 

--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -6,6 +6,8 @@ use crate::errors::Error;
 use crate::hash::Hash;
 use crate::opts::IntegrityOpts;
 
+use base64::Engine as _;
+
 #[cfg(feature = "serde")]
 use serde::de::{self, Deserialize, Deserializer, Visitor};
 #[cfg(feature = "serde")]
@@ -187,7 +189,7 @@ impl Integrity {
         let hash = self.hashes.get(0).unwrap();
         (
             hash.algorithm,
-            hex::encode(base64::decode(&hash.digest).unwrap()),
+            hex::encode(base64::prelude::BASE64_STANDARD.encode(&hash.digest)),
         )
     }
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -63,10 +63,10 @@ impl IntegrityOpts {
         self.disturbed = true;
         for hasher in self.hashers.iter_mut() {
             match hasher {
-                Hasher::Sha1(h) => digest::Digest::input(h, &input),
-                Hasher::Sha256(h) => digest::Digest::input(h, &input),
-                Hasher::Sha384(h) => digest::Digest::input(h, &input),
-                Hasher::Sha512(h) => digest::Digest::input(h, &input),
+                Hasher::Sha1(h) => digest::Digest::update(h, &input),
+                Hasher::Sha256(h) => digest::Digest::update(h, &input),
+                Hasher::Sha384(h) => digest::Digest::update(h, &input),
+                Hasher::Sha512(h) => digest::Digest::update(h, &input),
             }
         }
     }
@@ -90,10 +90,10 @@ impl IntegrityOpts {
             .into_iter()
             .map(|h| {
                 let (algorithm, data) = match h {
-                    Hasher::Sha1(h) => (Algorithm::Sha1, base64::encode(&h.result())),
-                    Hasher::Sha256(h) => (Algorithm::Sha256, base64::encode(&h.result())),
-                    Hasher::Sha384(h) => (Algorithm::Sha384, base64::encode(&h.result())),
-                    Hasher::Sha512(h) => (Algorithm::Sha512, base64::encode(&h.result())),
+                    Hasher::Sha1(h) => (Algorithm::Sha1, base64::encode(&h.finalize())),
+                    Hasher::Sha256(h) => (Algorithm::Sha256, base64::encode(&h.finalize())),
+                    Hasher::Sha384(h) => (Algorithm::Sha384, base64::encode(&h.finalize())),
+                    Hasher::Sha512(h) => (Algorithm::Sha512, base64::encode(&h.finalize())),
                 };
                 Hash {
                     algorithm,
@@ -106,11 +106,11 @@ impl IntegrityOpts {
     }
 }
 
-impl digest::Input for IntegrityOpts {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
-        self.input(input)
+impl digest::Update for IntegrityOpts {
+    fn update(&mut self, data: &[u8]) {
+        self.input(data);
     }
-    fn chain<B: AsRef<[u8]>>(self, input: B) -> Self {
+    fn chain(self, input: impl AsRef<[u8]>) -> Self {
         self.chain(input)
     }
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -2,6 +2,8 @@ use crate::algorithm::Algorithm;
 use crate::hash::Hash;
 use crate::integrity::Integrity;
 
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine;
 use digest::Digest;
 
 #[allow(clippy::enum_variant_names)]
@@ -90,10 +92,10 @@ impl IntegrityOpts {
             .into_iter()
             .map(|h| {
                 let (algorithm, data) = match h {
-                    Hasher::Sha1(h) => (Algorithm::Sha1, base64::encode(&h.finalize())),
-                    Hasher::Sha256(h) => (Algorithm::Sha256, base64::encode(&h.finalize())),
-                    Hasher::Sha384(h) => (Algorithm::Sha384, base64::encode(&h.finalize())),
-                    Hasher::Sha512(h) => (Algorithm::Sha512, base64::encode(&h.finalize())),
+                    Hasher::Sha1(h) => (Algorithm::Sha1, BASE64_STANDARD.encode(h.finalize())),
+                    Hasher::Sha256(h) => (Algorithm::Sha256, BASE64_STANDARD.encode(h.finalize())),
+                    Hasher::Sha384(h) => (Algorithm::Sha384, BASE64_STANDARD.encode(h.finalize())),
+                    Hasher::Sha512(h) => (Algorithm::Sha512, BASE64_STANDARD.encode(h.finalize())),
                 };
                 Hash {
                     algorithm,


### PR DESCRIPTION
Hello!

I use `ssri` transitively through `cacache` and noticed some of the dependencies were a bit out of date.

I've gone through and updated every dependency to their latest versions, and fixed any issues I saw preventing compilation or tests from passing.

Although this repo does not specify a MSRV, this bumps the required rust version considerably. `latest` can compile on `1.38.0`, but this updated branch can now only compile on `1.57.0`. This is largely a non-issue upstream, but a couple crates would be "at risk" if this was a 7.x update:
- `cacache`/`cacache-sync` just recently changed to require `1.66.1`
- `yew-stdweb` depends on `^5` anyways
- `srisum` uses edition 2021, so _technically_ I suppose this could work on `1.56.0` but I haven't tried it
- `mensa` uses edition 2021 and specifies a MSRV of `1.56.0`.