### PR TITLE
Implemented Integrity::from_hash(), inverse of Integrity::to_hash()

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,4 +14,8 @@ pub enum Error {
     #[error("Integrity check failed.\n\tWanted: {0}\n\tActual: {1}")]
     #[diagnostic(code(ssri::integrity_check_error), url(docsrs))]
     IntegrityCheckError(Integrity, Integrity),
+    /// Error Decoding Hex Data
+    #[error("Failed decode hexadecimal data, reason: {0}")]
+    #[diagnostic(code(ssri::hex_decode_error), url(docsrs))]
+    HexDecodeError(String),
 }

--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -138,6 +138,23 @@ impl Integrity {
             .result()
     }
 
+    /// Converts a hex string obtained from `to_hex()` to an `Integrity` with a `Hash` containing algorithm and decoded hex string.
+    ///
+    /// # Example
+    ///```
+    /// use ssri::{Integrity, Algorithm};
+    ///
+    /// let expected = Integrity::from(b"hello");
+    /// let hex = String::from("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+    /// assert_eq!(Integrity::from_hex(hex, Algorithm::Sha256), expected);
+    ///```
+    pub fn from_hex<B: AsRef<[u8]>>(hex: B, algorithm: Algorithm) -> Integrity {
+        let digest = base64::prelude::BASE64_STANDARD.encode(hex::decode(hex).unwrap());
+        Integrity {
+            hashes: vec![Hash { algorithm, digest }],
+        }
+    }
+
     /// Join together two `Integrity` instances. Hashes will be grouped and
     /// sorted by algorithm but otherwise kept in the same order.
     ///
@@ -239,6 +256,16 @@ mod tests {
                 digest: String::from("deadbeef=")
             }
         )
+    }
+
+    #[test]
+    fn from_hex() {
+        let expected_integrity = Integrity::from(b"hello world");
+        let hex = String::from("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9");
+        assert_eq!(
+            Integrity::from_hex(hex, Algorithm::Sha256),
+            expected_integrity
+        );
     }
 
     #[test]

--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -149,10 +149,7 @@ impl Integrity {
     /// assert_eq!(Integrity::from_hex(hex, Algorithm::Sha256).unwrap(), expected);
     ///```
     pub fn from_hex<B: AsRef<[u8]>>(hex: B, algorithm: Algorithm) -> Result<Integrity, Error> {
-        let b16 = match hex::decode(hex) {
-            Ok(data) => data,
-            Err(e) => return Err(Error::HexDecodeError(e.to_string())),
-        };
+        let b16 = hex::decode(hex).map_err(|e| Error::HexDecodeError(e.to_string()))?;
         let digest = base64::prelude::BASE64_STANDARD.encode(b16);
         Ok(Integrity {
             hashes: vec![Hash { algorithm, digest }],

--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -146,13 +146,17 @@ impl Integrity {
     ///
     /// let expected = Integrity::from(b"hello");
     /// let hex = String::from("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
-    /// assert_eq!(Integrity::from_hex(hex, Algorithm::Sha256), expected);
+    /// assert_eq!(Integrity::from_hex(hex, Algorithm::Sha256).unwrap(), expected);
     ///```
-    pub fn from_hex<B: AsRef<[u8]>>(hex: B, algorithm: Algorithm) -> Integrity {
-        let digest = base64::prelude::BASE64_STANDARD.encode(hex::decode(hex).unwrap());
-        Integrity {
+    pub fn from_hex<B: AsRef<[u8]>>(hex: B, algorithm: Algorithm) -> Result<Integrity, Error> {
+        let b16 = match hex::decode(hex) {
+            Ok(data) => data,
+            Err(e) => return Err(Error::HexDecodeError(e.to_string())),
+        };
+        let digest = base64::prelude::BASE64_STANDARD.encode(b16);
+        Ok(Integrity {
             hashes: vec![Hash { algorithm, digest }],
-        }
+        })
     }
 
     /// Join together two `Integrity` instances. Hashes will be grouped and
@@ -263,7 +267,7 @@ mod tests {
         let expected_integrity = Integrity::from(b"hello world");
         let hex = String::from("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9");
         assert_eq!(
-            Integrity::from_hex(hex, Algorithm::Sha256),
+            Integrity::from_hex(hex, Algorithm::Sha256).unwrap(),
             expected_integrity
         );
     }


### PR DESCRIPTION
Includes doc-comment, doc-test and `from_hash()` test in `mod tests`.
Fixes #10 