### PR TITLE
feat(deps): Relax sha-1 dep constraint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ digest = "0.10.6"
 hex = "0.4.3"
 miette = "5.7.0"
 serde = { version = "1.0.152", optional = true }
-sha-1 = "0.10.1"
+sha-1 = "^0.10"
 sha2 = "0.10.6"
 thiserror = "1.0.40"
 xxhash-rust = { version = "0.8.6", features = ["xxh3"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ digest = "0.10.6"
 hex = "0.4.3"
 miette = "5.7.0"
 serde = { version = "1.0.152", optional = true }
-sha-1 = "^0.10"
+sha-1 = "0.10.0"
 sha2 = "0.10.6"
 thiserror = "1.0.40"
 xxhash-rust = { version = "0.8.6", features = ["xxh3"] }


### PR DESCRIPTION
I have a dep conflict happening within `http-cache-reqwest` that transitively uses this through `cacache`, and another crate (one of swc's) that has pinned sha-1 to `=0.10.0`, I tried resolving the pin on their side but all I got was 30 other pinned version conflicts.

I'd appreciate if this crate could get a patch release afterwards.