### PR TITLE
refactor(Hash): store raw digest bytes in arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 rust-version = "1.57.0"
 
 [dependencies]
-base64 = "0.21.0"
+base64 = "0.22.0"
 digest = "0.10.6"
 hex = "0.4.3"
 miette = "5.7.0"

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -46,7 +46,7 @@ impl IntegrityChecker {
         wanted
             .hashes
             .iter()
-            .take_while(|h| h.algorithm == algo)
+            .take_while(|h| h.algorithm() == algo)
             .find(|&h| *h == sri.hashes[0])
             .map(|_| algo)
             .ok_or(Error::IntegrityCheckError(wanted, sri))
@@ -67,7 +67,7 @@ mod tests {
     }
     #[test]
     fn multi_hash() {
-        let sri = "sha256-deadbeef"
+        let sri = "sha256-K68fQBBdlQH+MZqOxGP99DJaKl30Ra3z9XL2JiU2eMk="
             .parse::<Integrity>()
             .unwrap()
             .concat(Integrity::from(b"hello world"));

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,6 +1,9 @@
 use std::cmp::Ordering;
 use std::fmt;
 
+use base64::engine::general_purpose::STANDARD as STANDARD_BASE64;
+use base64::Engine;
+
 use crate::algorithm::Algorithm;
 use crate::errors::Error;
 
@@ -11,9 +14,111 @@ This is mostly internal, although users might interact with it directly on
 occasion.
 */
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Hash {
-    pub algorithm: Algorithm,
-    pub digest: String,
+#[non_exhaustive]
+pub enum Hash {
+    Sha512([u8; 64]),
+    Sha384([u8; 48]),
+    Sha256([u8; 32]),
+    Sha1([u8; 20]),
+    /// xxh3 is a non-cryptographic hash function that is very fast and can be
+    /// used to speed up integrity calculations, at the cost of
+    /// cryptographically-secure guarantees.
+    ///
+    /// `ssri` uses 128-bit xxh3 hashes, which have been shown to have no
+    /// conflicts even on billions of hashes.
+    Xxh3([u8; 16]),
+}
+
+impl Hash {
+    pub fn algorithm(&self) -> Algorithm {
+        match self {
+            Hash::Sha512(_) => Algorithm::Sha512,
+            Hash::Sha384(_) => Algorithm::Sha384,
+            Hash::Sha256(_) => Algorithm::Sha256,
+            Hash::Sha1(_) => Algorithm::Sha1,
+            Hash::Xxh3(_) => Algorithm::Xxh3,
+        }
+    }
+
+    pub fn digest(&self) -> &[u8] {
+        match self {
+            Hash::Sha512(d) => d,
+            Hash::Sha384(d) => d,
+            Hash::Sha256(d) => d,
+            Hash::Sha1(d) => d,
+            Hash::Xxh3(d) => d,
+        }
+    }
+
+    pub fn from_algorithm_digest(algorithm: Algorithm, digest: &[u8]) -> Result<Hash, Error> {
+        match algorithm {
+            Algorithm::Sha512 => {
+                let mut hash = [0; 64];
+                if digest.len() != hash.len() {
+                    return Err(Error::ParseIntegrityError(format!(
+                        "Digest has invalid length of {} bytes - a {} hash needs to have {} bytes",
+                        digest.len(),
+                        algorithm,
+                        hash.len()
+                    )));
+                }
+                hash.copy_from_slice(digest);
+                Ok(Hash::Sha512(hash))
+            }
+            Algorithm::Sha384 => {
+                let mut hash = [0; 48];
+                if digest.len() != hash.len() {
+                    return Err(Error::ParseIntegrityError(format!(
+                        "Digest has invalid length of {} bytes - a {} hash needs to have {} bytes",
+                        digest.len(),
+                        algorithm,
+                        hash.len()
+                    )));
+                }
+                hash.copy_from_slice(digest);
+                Ok(Hash::Sha384(hash))
+            }
+            Algorithm::Sha256 => {
+                let mut hash = [0; 32];
+                if digest.len() != hash.len() {
+                    return Err(Error::ParseIntegrityError(format!(
+                        "Digest has invalid length of {} bytes - a {} hash needs to have {} bytes",
+                        digest.len(),
+                        algorithm,
+                        hash.len()
+                    )));
+                }
+                hash.copy_from_slice(digest);
+                Ok(Hash::Sha256(hash))
+            }
+            Algorithm::Sha1 => {
+                let mut hash = [0; 20];
+                if digest.len() != hash.len() {
+                    return Err(Error::ParseIntegrityError(format!(
+                        "Digest has invalid length of {} bytes - a {} hash needs to have {} bytes",
+                        digest.len(),
+                        algorithm,
+                        hash.len()
+                    )));
+                }
+                hash.copy_from_slice(digest);
+                Ok(Hash::Sha1(hash))
+            }
+            Algorithm::Xxh3 => {
+                let mut hash = [0; 16];
+                if digest.len() != hash.len() {
+                    return Err(Error::ParseIntegrityError(format!(
+                        "Digest has invalid length of {} bytes - a {} hash needs to have {} bytes",
+                        digest.len(),
+                        algorithm,
+                        hash.len()
+                    )));
+                }
+                hash.copy_from_slice(digest);
+                Ok(Hash::Xxh3(hash))
+            }
+        }
+    }
 }
 
 impl PartialOrd for Hash {
@@ -24,12 +129,17 @@ impl PartialOrd for Hash {
 
 impl Ord for Hash {
     fn cmp(&self, other: &Hash) -> Ordering {
-        self.algorithm.cmp(&other.algorithm)
+        self.algorithm().cmp(&other.algorithm())
     }
 }
 impl fmt::Display for Hash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}-{}", self.algorithm, self.digest)
+        write!(
+            f,
+            "{}-{}",
+            self.algorithm(),
+            STANDARD_BASE64.encode(self.digest())
+        )
     }
 }
 
@@ -45,18 +155,85 @@ impl std::str::FromStr for Hash {
             .next()
             .ok_or_else(|| Error::ParseIntegrityError(s.into()))?
             .parse()?;
-        let digest = String::from(
-            parsed
-                .next()
-                .ok_or_else(|| Error::ParseIntegrityError(s.into()))?,
-        );
-        Ok(Hash { algorithm, digest })
+        let digest_str = parsed
+            .next()
+            .ok_or_else(|| Error::ParseIntegrityError(s.into()))?
+            .trim_end();
+        let digest = STANDARD_BASE64
+            .decode(digest_str)
+            .map_err(|e| Error::ParseIntegrityError(e.to_string()))?;
+        Ok(match algorithm {
+            Algorithm::Sha512 => {
+                let mut hash = [0; 64];
+                if digest.len() != hash.len() {
+                    return Err(Error::ParseIntegrityError(format!(
+                        "Parsed {} bytes of hash - a {} hash should be {} bytes long",
+                        digest.len(),
+                        algorithm,
+                        hash.len()
+                    )));
+                }
+                hash.copy_from_slice(&digest);
+                Hash::Sha512(hash)
+            }
+            Algorithm::Sha384 => {
+                let mut hash = [0; 48];
+                if digest.len() != hash.len() {
+                    return Err(Error::ParseIntegrityError(format!(
+                        "Parsed {} bytes of hash - a {} hash should be {} bytes long",
+                        digest.len(),
+                        algorithm,
+                        hash.len()
+                    )));
+                }
+                hash.copy_from_slice(&digest);
+                Hash::Sha384(hash)
+            }
+            Algorithm::Sha256 => {
+                let mut hash = [0; 32];
+                if digest.len() != hash.len() {
+                    return Err(Error::ParseIntegrityError(format!(
+                        "Parsed {} bytes of hash - a {} hash should be {} bytes long",
+                        digest.len(),
+                        algorithm,
+                        hash.len()
+                    )));
+                }
+                hash.copy_from_slice(&digest);
+                Hash::Sha256(hash)
+            }
+            Algorithm::Sha1 => {
+                let mut hash = [0; 20];
+                if digest.len() != hash.len() {
+                    return Err(Error::ParseIntegrityError(format!(
+                        "Parsed {} bytes of hash - a {} hash should be {} bytes long",
+                        digest.len(),
+                        algorithm,
+                        hash.len()
+                    )));
+                }
+                hash.copy_from_slice(&digest);
+                Hash::Sha1(hash)
+            }
+            Algorithm::Xxh3 => {
+                let mut hash = [0; 16];
+                if digest.len() != hash.len() {
+                    return Err(Error::ParseIntegrityError(format!(
+                        "Parsed {} bytes of hash - a {} hash should be {} bytes long",
+                        digest.len(),
+                        algorithm,
+                        hash.len()
+                    )));
+                }
+                hash.copy_from_slice(&digest);
+                Hash::Xxh3(hash)
+            }
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Algorithm;
     use super::Hash;
 
     #[test]
@@ -64,23 +241,27 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Hash {
-                    algorithm: Algorithm::Sha256,
-                    digest: String::from("deadbeef==")
-                }
+                // list(hashlib.sha256(b'ssri').digest())
+                Hash::Sha256([
+                    147, 173, 211, 33, 34, 65, 228, 109, 188, 158, 107, 211, 188, 16, 188, 192,
+                    153, 126, 82, 213, 54, 128, 221, 0, 81, 60, 238, 24, 64, 203, 122, 38
+                ])
             ),
-            "sha256-deadbeef=="
+            // "sha256-" + base64.encodebytes(hashlib.sha256(b'ssri').digest()).decode('utf-8').strip()
+            "sha256-k63TISJB5G28nmvTvBC8wJl+UtU2gN0AUTzuGEDLeiY="
         )
     }
 
     #[test]
     fn parsing() {
         assert_eq!(
-            " sha256-deadbeef== \n".parse::<Hash>().unwrap(),
-            Hash {
-                algorithm: Algorithm::Sha256,
-                digest: String::from("deadbeef==")
-            }
+            " sha256-k63TISJB5G28nmvTvBC8wJl+UtU2gN0AUTzuGEDLeiY= \n"
+                .parse::<Hash>()
+                .unwrap(),
+            Hash::Sha256([
+                147, 173, 211, 33, 34, 65, 228, 109, 188, 158, 107, 211, 188, 16, 188, 192, 153,
+                126, 82, 213, 54, 128, 221, 0, 81, 60, 238, 24, 64, 203, 122, 38
+            ])
         )
     }
 
@@ -94,51 +275,21 @@ mod tests {
     #[test]
     fn ordering() {
         let mut arr = [
-            Hash {
-                algorithm: Algorithm::Sha1,
-                digest: String::from("foo=="),
-            },
-            Hash {
-                algorithm: Algorithm::Sha256,
-                digest: String::from("foo=="),
-            },
-            Hash {
-                algorithm: Algorithm::Sha384,
-                digest: String::from("foo=="),
-            },
-            Hash {
-                algorithm: Algorithm::Sha512,
-                digest: String::from("foo=="),
-            },
-            Hash {
-                algorithm: Algorithm::Xxh3,
-                digest: String::from("foo=="),
-            },
+            Hash::Sha1([0; 20]),
+            Hash::Sha256([0; 32]),
+            Hash::Sha384([0; 48]),
+            Hash::Sha512([0; 64]),
+            Hash::Xxh3([0; 16]),
         ];
         arr.sort_unstable();
         assert_eq!(
             arr,
             [
-                Hash {
-                    algorithm: Algorithm::Sha512,
-                    digest: String::from("foo==")
-                },
-                Hash {
-                    algorithm: Algorithm::Sha384,
-                    digest: String::from("foo==")
-                },
-                Hash {
-                    algorithm: Algorithm::Sha256,
-                    digest: String::from("foo==")
-                },
-                Hash {
-                    algorithm: Algorithm::Sha1,
-                    digest: String::from("foo==")
-                },
-                Hash {
-                    algorithm: Algorithm::Xxh3,
-                    digest: String::from("foo==")
-                }
+                Hash::Sha512([0; 64]),
+                Hash::Sha384([0; 48]),
+                Hash::Sha256([0; 32]),
+                Hash::Sha1([0; 20]),
+                Hash::Xxh3([0; 16]),
             ]
         )
     }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -159,73 +159,80 @@ impl std::str::FromStr for Hash {
             .next()
             .ok_or_else(|| Error::ParseIntegrityError(s.into()))?
             .trim_end();
-        let digest = STANDARD_BASE64
-            .decode(digest_str)
-            .map_err(|e| Error::ParseIntegrityError(e.to_string()))?;
         Ok(match algorithm {
             Algorithm::Sha512 => {
                 let mut hash = [0; 64];
-                if digest.len() != hash.len() {
+                let decoded_size = STANDARD_BASE64
+                    .decode_slice(digest_str, &mut hash)
+                    .map_err(|e| Error::ParseIntegrityError(e.to_string()))?;
+                if decoded_size != hash.len() {
                     return Err(Error::ParseIntegrityError(format!(
                         "Parsed {} bytes of hash - a {} hash should be {} bytes long",
-                        digest.len(),
+                        decoded_size,
                         algorithm,
                         hash.len()
                     )));
                 }
-                hash.copy_from_slice(&digest);
                 Hash::Sha512(hash)
             }
             Algorithm::Sha384 => {
                 let mut hash = [0; 48];
-                if digest.len() != hash.len() {
+                let decoded_size = STANDARD_BASE64
+                    .decode_slice(digest_str, &mut hash)
+                    .map_err(|e| Error::ParseIntegrityError(e.to_string()))?;
+                if decoded_size != hash.len() {
                     return Err(Error::ParseIntegrityError(format!(
                         "Parsed {} bytes of hash - a {} hash should be {} bytes long",
-                        digest.len(),
+                        decoded_size,
                         algorithm,
                         hash.len()
                     )));
                 }
-                hash.copy_from_slice(&digest);
                 Hash::Sha384(hash)
             }
             Algorithm::Sha256 => {
                 let mut hash = [0; 32];
-                if digest.len() != hash.len() {
+                let decoded_size = STANDARD_BASE64
+                    .decode_slice(digest_str, &mut hash)
+                    .map_err(|e| Error::ParseIntegrityError(e.to_string()))?;
+                if decoded_size != hash.len() {
                     return Err(Error::ParseIntegrityError(format!(
                         "Parsed {} bytes of hash - a {} hash should be {} bytes long",
-                        digest.len(),
+                        decoded_size,
                         algorithm,
                         hash.len()
                     )));
                 }
-                hash.copy_from_slice(&digest);
                 Hash::Sha256(hash)
             }
             Algorithm::Sha1 => {
                 let mut hash = [0; 20];
-                if digest.len() != hash.len() {
+                let decoded_size = STANDARD_BASE64
+                    .decode_slice(digest_str, &mut hash)
+                    .map_err(|e| Error::ParseIntegrityError(e.to_string()))?;
+                if decoded_size != hash.len() {
                     return Err(Error::ParseIntegrityError(format!(
                         "Parsed {} bytes of hash - a {} hash should be {} bytes long",
-                        digest.len(),
+                        decoded_size,
                         algorithm,
                         hash.len()
                     )));
                 }
-                hash.copy_from_slice(&digest);
                 Hash::Sha1(hash)
             }
             Algorithm::Xxh3 => {
                 let mut hash = [0; 16];
-                if digest.len() != hash.len() {
+                let decoded_size = STANDARD_BASE64
+                    .decode_slice(digest_str, &mut hash)
+                    .map_err(|e| Error::ParseIntegrityError(e.to_string()))?;
+                if decoded_size != hash.len() {
                     return Err(Error::ParseIntegrityError(format!(
                         "Parsed {} bytes of hash - a {} hash should be {} bytes long",
-                        digest.len(),
+                        decoded_size,
                         algorithm,
                         hash.len()
                     )));
                 }
-                hash.copy_from_slice(&digest);
                 Hash::Xxh3(hash)
             }
         })
@@ -272,9 +279,17 @@ mod tests {
     }
 
     #[test]
-    fn bad_length() {
+    fn bad_length_short() {
         // TODO - test the actual error returned when it's more valuable
         assert!("sha1-deadbeef==".parse::<Hash>().is_err());
+    }
+
+    #[test]
+    fn bad_length_long() {
+        // TODO - test the actual error returned when it's more valuable
+        assert!("sha1-deadbeefdeadbeefdeadbeefdeadbeef=="
+            .parse::<Hash>()
+            .is_err());
     }
 
     #[test]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -266,17 +266,15 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn bad_algorithm() {
         // TODO - test the actual error returned when it's more valuable
-        "sha7-deadbeef==".parse::<Hash>().unwrap();
+        assert!("sha7-deadbeef==".parse::<Hash>().is_err());
     }
 
     #[test]
-    #[should_panic]
     fn bad_length() {
         // TODO - test the actual error returned when it's more valuable
-        "sha1-deadbeef==".parse::<Hash>().unwrap();
+        assert!("sha1-deadbeef==".parse::<Hash>().is_err());
     }
 
     #[test]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -273,6 +273,13 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
+    fn bad_length() {
+        // TODO - test the actual error returned when it's more valuable
+        "sha1-deadbeef==".parse::<Hash>().unwrap();
+    }
+
+    #[test]
     fn ordering() {
         let mut arr = [
             Hash::Sha1([0; 20]),

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -50,6 +50,19 @@ impl Hash {
         }
     }
 
+    pub fn digest_base64(&self) -> String {
+        STANDARD_BASE64.encode(self.digest())
+    }
+
+    pub fn from_algorithm_digest_str(algorithm: Algorithm, digest: &str) -> Result<Hash, Error> {
+        Hash::from_algorithm_digest(
+            algorithm,
+            &STANDARD_BASE64
+                .decode(digest)
+                .map_err(|e| Error::ParseIntegrityError(e.to_string()))?,
+        )
+    }
+
     pub fn from_algorithm_digest(algorithm: Algorithm, digest: &[u8]) -> Result<Hash, Error> {
         match algorithm {
             Algorithm::Sha512 => {
@@ -134,12 +147,7 @@ impl Ord for Hash {
 }
 impl fmt::Display for Hash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}-{}",
-            self.algorithm(),
-            STANDARD_BASE64.encode(self.digest())
-        )
+        write!(f, "{}-{}", self.algorithm(), self.digest_base64())
     }
 }
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -4,8 +4,6 @@ use crate::algorithm::Algorithm;
 use crate::hash::Hash;
 use crate::integrity::Integrity;
 
-use base64::prelude::BASE64_STANDARD;
-use base64::Engine;
 use digest::Digest;
 
 #[allow(clippy::enum_variant_names)]
@@ -109,21 +107,12 @@ impl IntegrityOpts {
         let mut hashes = self
             .hashers
             .into_iter()
-            .map(|h| {
-                let (algorithm, data) = match h {
-                    Hasher::Sha1(h) => (Algorithm::Sha1, BASE64_STANDARD.encode(h.finalize())),
-                    Hasher::Sha256(h) => (Algorithm::Sha256, BASE64_STANDARD.encode(h.finalize())),
-                    Hasher::Sha384(h) => (Algorithm::Sha384, BASE64_STANDARD.encode(h.finalize())),
-                    Hasher::Sha512(h) => (Algorithm::Sha512, BASE64_STANDARD.encode(h.finalize())),
-                    Hasher::Xxh3(h) => (
-                        Algorithm::Xxh3,
-                        BASE64_STANDARD.encode(h.digest128().to_be_bytes()),
-                    ),
-                };
-                Hash {
-                    algorithm,
-                    digest: data,
-                }
+            .map(|h| match h {
+                Hasher::Sha1(h) => Hash::Sha1(h.finalize().into()),
+                Hasher::Sha256(h) => Hash::Sha256(h.finalize().into()),
+                Hasher::Sha384(h) => Hash::Sha384(h.finalize().into()),
+                Hasher::Sha512(h) => Hash::Sha512(h.finalize().into()),
+                Hasher::Xxh3(h) => Hash::Xxh3(h.digest128().to_be_bytes()),
             })
             .collect::<Vec<Hash>>();
         hashes.sort();


### PR DESCRIPTION
BREAKING CHANGE: new type signature of Hash, digest lengths are now validated

Fixes: https://github.com/zkat/ssri-rs/issues/5