### PR TITLE
feat: make IntegrityChecker and IntegrityOpts an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,20 @@ rust-version = "1.57.0"
 
 [dependencies]
 base64 = "0.21.0"
-digest = "0.10.6"
+digest = { version = "0.10.6", optional = true }
 hex = "0.4.3"
 miette = "5.7.0"
 serde = { version = "1.0.152", optional = true }
-sha-1 = "0.10.0"
-sha2 = "0.10.6"
+sha-1 = { version = "0.10.0", optional = true }
+sha2 = { version = "0.10.6", optional = true }
 thiserror = "1.0.40"
-xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
+xxhash-rust = { version = "0.8.6", features = ["xxh3"], optional = true }
 
 [features]
-default = ["serde"]
+default = ["hasher", "serde"]
+
+# Enable [IntegrityChecker], [IntegrityOpts], and all algorithms
+hasher = ["digest", "sha-1", "sha2", "xxhash-rust"]
 
 [dev-dependencies]
 serde_derive = "1.0.152"

--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -1,9 +1,11 @@
 use std::fmt;
 
 use crate::algorithm::Algorithm;
+#[cfg(feature = "hasher")]
 use crate::checker::IntegrityChecker;
 use crate::errors::Error;
 use crate::hash::Hash;
+#[cfg(feature = "hasher")]
 use crate::opts::IntegrityOpts;
 
 use base64::Engine as _;
@@ -131,6 +133,7 @@ impl Integrity {
     /// let sri = Integrity::from(b"hello");
     /// assert_eq!(sri.to_string(), "sha256-LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=".to_owned());
     /// ```
+    #[cfg(feature = "hasher")]
     pub fn from<B: AsRef<[u8]>>(data: B) -> Integrity {
         IntegrityOpts::new()
             .algorithm(Algorithm::Sha256)
@@ -185,6 +188,7 @@ impl Integrity {
     /// let algorithm = sri.check(b"hello").unwrap();
     /// assert_eq!(algorithm, Algorithm::Sha256);
     /// ```
+    #[cfg(feature = "hasher")]
     pub fn check<B: AsRef<[u8]>>(&self, data: B) -> Result<Algorithm, Error> {
         let mut checker = IntegrityChecker::new(self.clone());
         checker.input(&data);
@@ -245,7 +249,10 @@ impl Integrity {
 
 #[cfg(test)]
 mod tests {
-    use super::{Algorithm, Hash, Integrity, IntegrityOpts};
+    use super::{Algorithm, Hash, Integrity};
+
+    #[cfg(feature = "hasher")]
+    use super::IntegrityOpts;
 
     #[test]
     fn parse() {
@@ -260,6 +267,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "hasher")]
     fn from_hex() {
         let expected_integrity = Integrity::from(b"hello world");
         let hex = String::from("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9");
@@ -270,6 +278,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "hasher")]
     fn to_hex() {
         let sri = Integrity::from(b"hello world");
         assert_eq!(
@@ -282,6 +291,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "hasher")]
     fn matches() {
         let sri1 = IntegrityOpts::new()
             .algorithm(Algorithm::Sha512)
@@ -296,6 +306,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn de_json() {
         use serde_derive::Deserialize;
 
@@ -316,6 +327,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn ser_json() {
         use serde_derive::Serialize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,15 +37,19 @@ incremental/streamed data input.
 */
 
 mod algorithm;
+#[cfg(feature = "hasher")]
 mod checker;
 mod errors;
 mod hash;
 mod integrity;
+#[cfg(feature = "hasher")]
 mod opts;
 
 pub use algorithm::Algorithm::{self, *};
+#[cfg(feature = "hasher")]
 pub use checker::IntegrityChecker;
 pub use errors::Error;
 pub use hash::Hash;
 pub use integrity::Integrity;
+#[cfg(feature = "hasher")]
 pub use opts::IntegrityOpts;


### PR DESCRIPTION
Default enabled.

BREAKING CHANGE: This hides existing APIs for users who set default-features=False